### PR TITLE
Release 1.8.0

### DIFF
--- a/test/copy_outputs.yaml
+++ b/test/copy_outputs.yaml
@@ -28,3 +28,8 @@ disambiguate:
     path: /juno/bic/work/ci/jenkins/resources/pipeline_data/data/disambiguate/foo_tumor_disambiguate_summary.txt
   - class: File
     path: /juno/bic/work/ci/jenkins/resources/pipeline_data/data/disambiguate/bar_tumor_disambiguate_summary.txt
+bed:
+  - class: File
+    path: /juno/bic/work/ci/jenkins/resources/pipeline_data/data/bed/bar_tumor.bar_normal.fci.bed
+  - class: File
+    path: /juno/bic/work/ci/jenkins/resources/pipeline_data/data/bed/foo_tumor.foo_normal.fci.bed

--- a/test/copy_outputs_without_meta.yaml
+++ b/test/copy_outputs_without_meta.yaml
@@ -18,3 +18,8 @@ pileup:
     path: /juno/work/ci/jenkins/resources/pipeline_data/data/PairWorkflowPair0/PairWorkflow/foo_tumor.rg.md.pileup
   - class: File
     path: /juno/work/ci/jenkins/resources/pipeline_data/data/PairWorkflowPair0/PairWorkflow/foo_normal.rg.md.pileup
+bed:
+  - class: File
+    path: /juno/bic/work/ci/jenkins/resources/pipeline_data/data/bed/bar_tumor.bar_normal.fci.bed
+  - class: File
+    path: /juno/bic/work/ci/jenkins/resources/pipeline_data/data/bed/foo_tumor.foo_normal.fci.bed

--- a/tools/consolidate-files/consolidate-files.cwl
+++ b/tools/consolidate-files/consolidate-files.cwl
@@ -23,7 +23,7 @@ inputs:
 outputs:
 
   directory:
-    type: Directory
+    type: Directory?
 
 # This tool returns a Directory object,
 # which holds all output files from the list
@@ -39,6 +39,10 @@ expression: |
         output_files.push(inputs.files[i]);
       }
     }
+
+    if (output_files.length == 0 ){
+      return {'directory': {} }
+      }
 
     return {
       'directory': {

--- a/workflows/copy_outputs.cwl
+++ b/workflows/copy_outputs.cwl
@@ -26,19 +26,19 @@ inputs:
 outputs:
 
   vcf_dir:
-    type: Directory
+    type: Directory?
     outputSource: collect_vcf/directory
   bam_dir:
-    type: Directory
+    type: Directory?
     outputSource: collect_bam/directory
   maf_dir:
-    type: Directory
+    type: Directory?
     outputSource: collect_maf/directory
   pileup_dir:
-    type: Directory
+    type: Directory?
     outputSource: collect_pileup/directory
   disambiguate_dir:
-    type: Directory
+    type: Directory?
     outputSource: collect_disambiguate/directory
   meta_files:
     type: File[]

--- a/workflows/copy_outputs.cwl
+++ b/workflows/copy_outputs.cwl
@@ -14,6 +14,7 @@ inputs:
 
   vcf: File[]
   bam: File[]
+  bed: File[]
   maf: File[]
   pileup: File[]
   disambiguate:
@@ -31,6 +32,9 @@ outputs:
   bam_dir:
     type: Directory?
     outputSource: collect_bam/directory
+  bed_dir:
+    type: Directory?
+    outputSource: collect_bed/directory
   maf_dir:
     type: Directory?
     outputSource: collect_maf/directory
@@ -59,6 +63,13 @@ steps:
       files: bam
       output_directory_name:
         valueFrom: ${ return "bam"; }
+    out: [directory]
+  collect_bed:
+    run: ../tools/consolidate-files/consolidate-files.cwl
+    in:
+      files: bed
+      output_directory_name:
+        valueFrom: ${ return "bed"; }
     out: [directory]
   collect_maf:
     run: ../tools/consolidate-files/consolidate-files.cwl

--- a/workflows/pair-workflow-sv.cwl
+++ b/workflows/pair-workflow-sv.cwl
@@ -209,7 +209,7 @@ outputs:
     type: File[]
     outputSource: alignment/conpair_pileup
   coverage_beds:
-    type: File[]
+    type: File
     outputSource: alignment/bed
   
   # disambiguate info

--- a/workflows/pair-workflow-sv.cwl
+++ b/workflows/pair-workflow-sv.cwl
@@ -208,6 +208,9 @@ outputs:
   conpair_pileups:
     type: File[]
     outputSource: alignment/conpair_pileup
+  coverage_beds:
+    type: File[]
+    outputSource: alignment/bed
   
   # disambiguate info
   disambiguate_summary:

--- a/workflows/pair-workflow.cwl
+++ b/workflows/pair-workflow.cwl
@@ -209,7 +209,7 @@ outputs:
     type: File[]
     outputSource: alignment/conpair_pileup
   coverage_beds:
-    type: File[]
+    type: File
     outputSource: alignment/bed
 
   # disambiguate info

--- a/workflows/pair-workflow.cwl
+++ b/workflows/pair-workflow.cwl
@@ -208,6 +208,9 @@ outputs:
   conpair_pileups:
     type: File[]
     outputSource: alignment/conpair_pileup
+  coverage_beds:
+    type: File[]
+    outputSource: alignment/bed
 
   # disambiguate info
   disambiguate_summary:


### PR DESCRIPTION
- Add coverage bed file as output
- Does not create disambiguate directory if it was not ran